### PR TITLE
Fix wrong processing if character map path is given

### DIFF
--- a/python/rapidocr_onnxruntime/ch_ppocr_v3_rec/text_recognize.py
+++ b/python/rapidocr_onnxruntime/ch_ppocr_v3_rec/text_recognize.py
@@ -31,7 +31,7 @@ class TextRecognizer:
         if self.session.have_key():
             self.character_dict_path = self.session.get_character_list()
         else:
-            self.character_dict_path = config.get("keys_path", None)
+            self.character_dict_path = config.get("rec_character_dict_path", None)
         self.postprocess_op = CTCLabelDecode(self.character_dict_path)
 
         self.rec_batch_num = config["rec_batch_num"]


### PR DESCRIPTION
Currently if the mode does not contain character map and you are to give it as a kwargs parameter the processing of the config object will prevent configuring this parameter.

Changing it to `rec_character_dict_path` (or `rec_keys_path`) will allow it's usage like that:

```
RapidOCR(det_model_path="models/det_onnx/model.onnx",
                            rec_model_path="models/rec_onnx/model.onnx",
                            cls_model_path="models/cls_onnx/model.onnx",
                            rec_character_dict_path="models/en_dict.txt")
                            
# based on the earlier naming this could also be an option:

RapidOCR(det_model_path="models/det_onnx/model.onnx",
                            rec_model_path="models/rec_onnx/model.onnx",
                            cls_model_path="models/cls_onnx/model.onnx",
                            rec_keys_path="models/en_dict.txt")


```