### PR TITLE
Fix get_boxes_img_without_det in the python api

### DIFF
--- a/python/rapidocr_onnxruntime/main.py
+++ b/python/rapidocr_onnxruntime/main.py
@@ -126,7 +126,7 @@ class RapidOCR:
 
     def get_boxes_img_without_det(self, h, w):
         x0, y0, x1, y1 = 0, 0, w, h
-        dt_boxes = np.array([[x0, y0], [x1, y0], [x1, y1], [x0, y1]])
+        dt_boxes = np.float32([[x0, y0], [x1, y0], [x1, y1], [x0, y1]])
         dt_boxes = dt_boxes[np.newaxis, ...]
         return dt_boxes
 


### PR DESCRIPTION
Without this change, it just crashes when get_boxes_img_without_det is called
<img width="1334" alt="image" src="https://github.com/RapidAI/RapidOCR/assets/15571693/19c2e44c-92f3-4b8a-9bd4-8973ff4adf85">
