### PR TITLE
add letterbox-like resize function in the python api

### DIFF
--- a/python/rapidocr_onnxruntime/config.yaml
+++ b/python/rapidocr_onnxruntime/config.yaml
@@ -6,7 +6,8 @@ Global:
     print_verbose: false
     min_height: 30
     width_height_ratio: 8
-
+    use_letterbox_like: true
+    
 Det:
     use_cuda: false
 

--- a/python/rapidocr_onnxruntime/main.py
+++ b/python/rapidocr_onnxruntime/main.py
@@ -63,11 +63,13 @@ class RapidOCR:
         use_det: Optional[bool] = None,
         use_cls: Optional[bool] = None,
         use_rec: Optional[bool] = None,
+        use_letterbox_like: Optional[bool] = None,
         **kwargs,
     ):
         use_det = self.use_det if use_det is None else use_det
         use_cls = self.use_cls if use_cls is None else use_cls
         use_rec = self.use_rec if use_rec is None else use_rec
+        self.use_letterbox_like = self.use_letterbox_like if use_letterbox_like is None else use_letterbox_like
 
         if kwargs:
             box_thresh = kwargs.get("box_thresh", 0.5)
@@ -261,8 +263,9 @@ def main():
     use_det = not args.no_det
     use_cls = not args.no_cls
     use_rec = not args.no_rec
+    use_letterbox_like = not args.no_letterbox_like
     result, elapse_list = ocr_engine(
-        args.img_path, use_det=use_det, use_cls=use_cls, use_rec=use_rec
+        args.img_path, use_det=use_det, use_cls=use_cls, use_rec=use_rec, use_letterbox_like = use_letterbox_like
     )
     print(result)
 

--- a/python/rapidocr_onnxruntime/utils.py
+++ b/python/rapidocr_onnxruntime/utils.py
@@ -234,7 +234,8 @@ def init_args():
     global_group.add_argument("--print_verbose", action="store_true", default=False)
     global_group.add_argument("--min_height", type=int, default=30)
     global_group.add_argument("--width_height_ratio", type=int, default=8)
-
+    global_group.add_argument("--no_letterbox_like",  action="store_true", default=False)
+    
     det_group = parser.add_argument_group(title="Det")
     det_group.add_argument("--det_use_cuda", action="store_true", default=False)
     det_group.add_argument("--det_model_path", type=str, default=None)


### PR DESCRIPTION
Implement a letterbox-like resize function for images with an aspect ratio that exceeds the specified ratio in the Python API. The function can be controlled to enable or disable by the parameter `use_letterbox_like`, which is set to enable (True) by default.
![test image](https://github.com/RapidAI/RapidOCR/assets/117698078/de950e7d-7a8b-40f9-9bc7-bd75a349a82f)
![OCR result for test image](https://github.com/RapidAI/RapidOCR/assets/117698078/6e110a9b-ccde-419d-bb87-4b10f06b6adc)
![letterbox-like image](https://github.com/RapidAI/RapidOCR/assets/117698078/b58f40c7-d348-418e-9bd4-2963d020c47f)
![OCR result for letterbox-like image](https://github.com/RapidAI/RapidOCR/assets/117698078/eb009283-10c7-4adb-8729-3b52cff1b038)