### PR TITLE
fix(config): Make ONNX Runtime DirectML an optional configuration for  better compatibility

### DIFF
--- a/python/rapidocr_onnxruntime/config.yaml
+++ b/python/rapidocr_onnxruntime/config.yaml
@@ -15,6 +15,7 @@ Det:
     inter_op_num_threads: *inter_nums
 
     use_cuda: false
+    use_dml: false
 
     model_path: models/ch_PP-OCRv4_det_infer.onnx
 
@@ -33,6 +34,7 @@ Cls:
     inter_op_num_threads: *inter_nums
 
     use_cuda: false
+    use_dml: false
 
     model_path: models/ch_ppocr_mobile_v2.0_cls_infer.onnx
 
@@ -46,6 +48,7 @@ Rec:
     inter_op_num_threads: *inter_nums
 
     use_cuda: false
+    use_dml: false
 
     model_path: models/ch_PP-OCRv4_rec_infer.onnx
 


### PR DESCRIPTION
This commit introduces an optional configuration for using ONNX Runtime DirectML.

DirectML can significantly improve performance on newer devices, but it has stricter requirements and may not be suitable for all users.

By making it an optional configuration, we ensure better compatibility for users with older devices or who are running the CLI version, where the GPU's potential may not be fully utilized due to single inference models.

For more information on DirectML requirements, please refer to: https://github.com/microsoft/DirectML


根据讨论 https://github.com/RapidAI/RapidOCR/discussions/175

dml ep 在旧设备上表现不好，而且cli版本无法充分利用gpu 故切换至可选项