### PR TITLE
Modify the way CTCLabelDecode calculates confidence

### DIFF
--- a/python/rapidocr_onnxruntime/ch_ppocr_v3_rec/utils.py
+++ b/python/rapidocr_onnxruntime/ch_ppocr_v3_rec/utils.py
@@ -69,5 +69,5 @@ class CTCLabelDecode:
                 else:
                     conf_list.append(1)
             text = "".join(char_list)
-            result_list.append((text, np.mean(conf_list + [1e-50])))
+            result_list.append((text, np.mean(conf_list if any(conf_list) else [0])))
         return result_list

--- a/python/rapidocr_openvino/ch_ppocr_v3_rec/utils.py
+++ b/python/rapidocr_openvino/ch_ppocr_v3_rec/utils.py
@@ -67,5 +67,5 @@ class CTCLabelDecode:
                 else:
                     conf_list.append(1)
             text = "".join(char_list)
-            result_list.append((text, np.mean(conf_list + [1e-50])))
+            result_list.append((text, np.mean(conf_list if any(conf_list) else [0])))
         return result_list

--- a/python/rapidocr_paddle/ch_ppocr_v3_rec/utils.py
+++ b/python/rapidocr_paddle/ch_ppocr_v3_rec/utils.py
@@ -71,5 +71,5 @@ class CTCLabelDecode:
                 else:
                     conf_list.append(1)
             text = "".join(char_list)
-            result_list.append((text, np.mean(conf_list + [1e-50])))
+            result_list.append((text, np.mean(conf_list if any(conf_list) else [0])))
         return result_list


### PR DESCRIPTION
在阅读 rapidocr_onnxruntime 源码时发现，`CTCLableDecode` 中对平均预测概率的计算有一个小失误。

```python
result_list.append((text, np.mean(conf_list + [1e-50])))
```

其中 `conf_list + [1e-50]`，这样的做法也许是为了避免 `conf_list` 为空时会算出 nan 值。但如此会让平均概率总是更小（例如 `conf_list=[0.9, 0.9, 0.9]`，此时的平均概率应当是 0.9，但目前的代码会算出比 0.9 小得多的值 0.675），不符合直觉。

我认为应当改为这样的形式：

```python
result_list.append((text, np.mean(conf_list if any(conf_list) else [0])))
```

写 pr 时发现 rapidocr_paddle 和 rapidocr_openvino 都有这个问题，就一并替换了。