### PR TITLE
fix dml not work issue

### DIFF
--- a/python/rapidocr_onnxruntime/utils/parse_parameters.py
+++ b/python/rapidocr_onnxruntime/utils/parse_parameters.py
@@ -149,15 +149,15 @@ class UpdateParameters:
         global_dict, det_dict, cls_dict, rec_dict = self.parse_kwargs(**kwargs)
         new_config = {
             "Global": self.update_global_params(config["Global"], global_dict),
-            "Det": self.update_params(config["Det"], det_dict, "det_", None),
+            "Det": self.update_params(config["Det"], det_dict, "det_", ["det_model_path", "det_use_cuda", "det_use_dml"]),
             "Cls": self.update_params(
                 config["Cls"],
                 cls_dict,
                 "cls_",
-                ["cls_label_list", "cls_model_path", "cls_use_cuda"],
+                ["cls_label_list", "cls_model_path", "cls_use_cuda", "cls_use_dml"],
             ),
             "Rec": self.update_params(
-                config["Rec"], rec_dict, "rec_", ["rec_model_path", "rec_use_cuda"]
+                config["Rec"], rec_dict, "rec_", ["rec_model_path", "rec_use_cuda", "rec_use_dml"]
             ),
         }
 


### PR DESCRIPTION
v1.3.18 dml能跑，v1.3.20dml跑得有点问题，det cls rec三个模型只有det跑了GPU，预估是config漏了一部分。
没怎么看懂config具体怎么生效的，修改后dml跑起来是没问题了，cuda没测过，就是log会跑很多遍。
```cmd
(py312) C:\Users\skeathy\Desktop>rapidocr_onnxruntime -img 1.png --det_use_dml --rec_use_dml --cls_use_dml
2024-05-19 18:57:02,130 - OrtInferSession - INFO: Windows 10 or above detected, try to use DirectML as primary provider
2024-05-19 18:57:02,406 - OrtInferSession - INFO: Windows 10 or above detected, try to use DirectML as primary provider
2024-05-19 18:57:02,406 - OrtInferSession - INFO: Windows 10 or above detected, try to use DirectML as primary provider
2024-05-19 18:57:02,509 - OrtInferSession - INFO: Windows 10 or above detected, try to use DirectML as primary provider
2024-05-19 18:57:02,509 - OrtInferSession - INFO: Windows 10 or above detected, try to use DirectML as primary provider
2024-05-19 18:57:02,509 - OrtInferSession - INFO: Windows 10 or above detected, try to use DirectML as primary provider
2024-05-19 18:57:04,987 - RapidOCR - INFO: [[[[9.0, 14.0], [164.0, 8.0], [166.0, 56.0], [11.0, 62.0]], 'gpt总结', 0.9996559], [[[12.0, 112.0], [1622.0, 112.0], [1622.0, 139.0], [12.0, 139.0]], 'ONNXRuntime是一个开源的机器学习推理引I擎，支持在各种平台和设备上部署训练好的模型。ONNXRuntime-DirectML是其一个', 0.9819293], [[[12.0, 153.0], [1506.0, 153.0], [1506.0, 181.0], [12.0, 181.0]], '组件，利用DirectML库为Windows系统上的ONNX模型推理提供GPU加速，带来显著的性能提升和更广泛的硬 件支持。', 0.994225], [[[13.0, 227.0], [400.0, 228.0], [400.0, 256.0], [13.0, 255.0]], '使用DirectML的主要优势包括：', 0.97633404], [[[67.0, 301.0], [477.0, 301.0], [477.0, 328.0], [67.0, 328.0]], '加速推理：比CPU执行速度更快', 0.98157305], [[[67.0, 351.0], [228.0, 351.0], [228.0, 379.0], [67.0, 379.0]], '提高效率：', 0.99967796], [[[212.0, 349.0], [383.0, 351.0], [382.0, 379.0], [212.0, 377.0]], '优化资源利用', 0.9987423], [[[66.0, 400.0], [417.0, 400.0], [417.0, 427.0], [66.0, 427.0]], '广泛兼容性：支持各种GPU', 0.98928607], [[[69.0, 449.0], [221.0, 449.0], [221.0, 477.0], [69.0, 477.0]], ' 易于使用：', 0.9986345], [[[213.0, 448.0], [384.0, 450.0], [384.0, 478.0], [213.0, 476.0]], '简化集成过程', 0.99818945], [[[11.0, 520.0], [1635.0, 521.0], [1635.0, 553.0], [11.0, 552.0]], '总而言之，ONNX Runtime-DirectML为Windows 用户提供了高效便捷的ONNX 模型推理解决方案，尤其适合需要GPU 加速的机器', 0.9793981], [[[11.0, 563.0], [137.0, 563.0], [137.0, 594.0], [11.0, 594.0]], '学习任务。', 0.998273]]
```
其他的作者再看看。