### PR TITLE
change read_yaml order

### DIFF
--- a/python/rapidocr_onnxruntime/main.py
+++ b/python/rapidocr_onnxruntime/main.py
@@ -31,11 +31,11 @@ logger = get_logger("RapidOCR")
 
 class RapidOCR:
     def __init__(self, config_path: Optional[str] = None, **kwargs):
-        config = read_yaml(DEFAULT_CFG_PATH)
-        config = update_model_path(config)
-
         if config_path is not None and Path(config_path).exists:
             config = read_yaml(config_path)
+        else:
+            config = read_yaml(DEFAULT_CFG_PATH)
+        config = update_model_path(config)
 
         if kwargs:
             updater = UpdateParameters()


### PR DESCRIPTION
fisrt check the input args 
if the param named 'config_path'  exists, use 'config_path' first. if it is not exists, use the default one named 'DEFAULT_CFG_PATH'