### PR TITLE
fix(rapidocr_api): float type error, cause scores not to be displayed

### DIFF
--- a/api/rapidocr_api/main.py
+++ b/api/rapidocr_api/main.py
@@ -51,7 +51,7 @@ class OCRAPIUtils:
                 if isinstance(dat, str):
                     values["rec_txt"] = dat
 
-                if isinstance(dat, np.float64):
+                if isinstance(dat, np.float32):
                     values["score"] = f"{dat:.4f}"
 
                 if isinstance(dat, list):


### PR DESCRIPTION
rapidocr_api 浮点类型使用错误导致不显示分数