### PR TITLE
feat: pass custom ort session

### DIFF
--- a/python/rapidocr_onnxruntime/utils/infer_engine.py
+++ b/python/rapidocr_onnxruntime/utils/infer_engine.py
@@ -29,6 +29,12 @@ class EP(Enum):
 class OrtInferSession:
     def __init__(self, config: Dict[str, Any]):
         self.logger = get_logger("OrtInferSession")
+        if (session := config.get("session")) is not None:
+            if not isinstance(session, InferenceSession):
+                raise TypeError(f"Expected session to be an InferenceSession, got {type(session)}")
+            self.logger.debug("Using the provided InferenceSession for inference.")
+            self.session = session
+            return
 
         model_path = config.get("model_path", None)
         self._verify_model(model_path)


### PR DESCRIPTION
The library is opinionated about which ORT settings it exposes, such as the EPs it allows and which options are passed to them. This PR allows library users to provide their own ORT session through the existing config dictionary instead, giving more flexibility. It should not have any effect on existing usage.

This does mean that you have to use the underlying `TextDetector` classes etc. instead of `RapidOCR` in order to use this feature, since the latter assumes YAML configuration. This is okay in my use-case, but it may be useful to consider how to make code-based configuration easier out-of-the-box.