### PR TITLE
解决低版本onnxruntime<=1.8.0不支持Path路径

### DIFF
--- a/python/rapidocr_onnxruntime/utils/infer_engine.py
+++ b/python/rapidocr_onnxruntime/utils/infer_engine.py
@@ -41,7 +41,7 @@ class OrtInferSession:
 
         sess_opt = self._init_sess_opts(config)
         self.session = InferenceSession(
-            model_path,
+            str(model_path),
             sess_options=sess_opt,
             providers=EP_list,
         )


### PR DESCRIPTION
onnxruntime\capi\onnxruntime_inference_collection.py", line 272, in __init__
    raise TypeError("Unable to load from type '{0}'".format(type(path_or_bytes)))
TypeError: Unable to load from type '<class 'pathlib.WindowsPath'>'