### PR TITLE
The torch engine adds support for Ascend NPU

### DIFF
--- a/python/rapidocr/config.yaml
+++ b/python/rapidocr/config.yaml
@@ -64,6 +64,8 @@ EngineConfig:
     torch:
         use_cuda: false
         gpu_id: 0
+        use_npu: false
+        npu_id: 0
 
 Det:
     engine_type: "onnxruntime"


### PR DESCRIPTION
## 背景
- `onnxruntime`框架下的动态`shape`推理任务在`Ascend NPU`上支持不好，易触发`om`文件的编译，造成严重耗时。
- 经与华为技术人员沟通后，推荐使用`torch`引擎，经实际测验，效果稳定
## 验证环境
- 昇腾`910b`
- `docker`镜像：swr.cn-southwest-2.myhuaweicloud.com/atelier/pytorch_ascend:pytorch_2.5.1-cann_8.2.rc1-py_3.11-hce_2.0.2503-aarch64-snt9b-20250729103313-3a25129
- 镜像发布公告：https://support.huaweicloud.com/bulletin-modelarts/bulletin-modelarts_0039.html
## 使用示例
```python
from rapidocr import RapidOCR, EngineType
engine = RapidOCR(params = {
    "Det.engine_type": EngineType.TORCH,
    "Cls.engine_type": EngineType.TORCH,
    "Rec.engine_type": EngineType.TORCH,
    "EngineConfig.torch.use_npu": True,
    "EngineConfig.torch.npu_id": 1
})
img_path = "test.jpg"
result = engine(img_path)
print(result)
result.vis("vis_result.jpg")
```