### PR TITLE
fix: replace deprecated openvino.runtime import

### DIFF
--- a/python/rapidocr/inference_engine/openvino.py
+++ b/python/rapidocr/inference_engine/openvino.py
@@ -8,7 +8,10 @@ from typing import Any, Dict
 
 import numpy as np
 from omegaconf import DictConfig
-from openvino.runtime import Core
+try:
+    from openvino import Core
+except ImportError:  # fallback for older OpenVINO versions
+    from openvino.runtime import Core
 
 from ..utils.download_file import DownloadFile, DownloadFileInput
 from ..utils.log import logger


### PR DESCRIPTION
在使用较新版本的 OpenVINO 时，会出现如下警告：

```
DeprecationWarning: The `openvino.runtime` module is deprecated and will be removed in the 2026.0 release.
```

使用 `openvino` 替代 `openvino.runtime`。

- 更新相关 import，避免 DeprecationWarning
- 不影响现有功能和行为