### PR TITLE
fix: check model_root_dir only if model_path is None

### DIFF
--- a/python/rapidocr/inference_engine/mnn/main.py
+++ b/python/rapidocr/inference_engine/mnn/main.py
@@ -16,12 +16,15 @@ from ..base import FileInfo, InferSession
 
 class MNNInferSession(InferSession):
     def __init__(self, cfg: DictConfig):
-        model_root_dir = Path(cfg.get("model_root_dir"))
-        if not model_root_dir.exists():
-            raise FileNotFoundError(f"model_root_dir {model_root_dir} does not exist")
-
         model_path = cfg.get("model_path", None)
         if model_path is None:
+            # Check model_root_dir only if model_path is None
+            model_root_dir = Path(cfg.get("model_root_dir"))
+            if not model_root_dir.exists():
+                raise FileNotFoundError(
+                    f"model_root_dir {model_root_dir} does not exist"
+                )
+
             model_info = self.get_model_url(
                 FileInfo(
                     engine_type=cfg.engine_type,

--- a/python/rapidocr/inference_engine/onnxruntime/main.py
+++ b/python/rapidocr/inference_engine/onnxruntime/main.py
@@ -17,10 +17,6 @@ from .provider_config import ProviderConfig
 
 class OrtInferSession(InferSession):
     def __init__(self, cfg: Dict[str, Any]):
-        model_root_dir = Path(cfg.get("model_root_dir"))
-        if not model_root_dir.exists():
-            raise FileNotFoundError(f"model_root_dir {model_root_dir} does not exist")
-
         # support custom session (PR #451)
         session = cfg.get("session", None)
         if session is not None:
@@ -35,6 +31,13 @@ class OrtInferSession(InferSession):
 
         model_path = cfg.get("model_path", None)
         if model_path is None:
+            # Check model_root_dir only if model_path is None
+            model_root_dir = Path(cfg.get("model_root_dir"))
+            if not model_root_dir.exists():
+                raise FileNotFoundError(
+                    f"model_root_dir {model_root_dir} does not exist"
+                )
+
             # 说明用户没有指定自己模型，使用默认模型
             model_info = self.get_model_url(
                 FileInfo(

--- a/python/rapidocr/inference_engine/openvino/main.py
+++ b/python/rapidocr/inference_engine/openvino/main.py
@@ -21,14 +21,17 @@ from .device_config import CPUConfig
 
 class OpenVINOInferSession(InferSession):
     def __init__(self, cfg: DictConfig):
-        model_root_dir = Path(cfg.get("model_root_dir"))
-        if not model_root_dir.exists():
-            raise FileNotFoundError(f"model_root_dir {model_root_dir} does not exist")
-
         core = Core()
 
         model_path = cfg.get("model_path", None)
         if model_path is None:
+            # Check model_root_dir only if model_path is None
+            model_root_dir = Path(cfg.get("model_root_dir"))
+            if not model_root_dir.exists():
+                raise FileNotFoundError(
+                    f"model_root_dir {model_root_dir} does not exist"
+                )
+
             model_info = self.get_model_url(
                 FileInfo(
                     engine_type=cfg.engine_type,

--- a/python/rapidocr/inference_engine/tensorrt/main.py
+++ b/python/rapidocr/inference_engine/tensorrt/main.py
@@ -19,12 +19,6 @@ from .memory_utils import allocate_buffers, free_buffers
 
 class TRTInferSession(InferSession):
     def __init__(self, cfg: Dict[str, Any]):
-        self.model_root_dir = Path(cfg.get("model_root_dir"))
-        if not self.model_root_dir.exists():
-            raise FileNotFoundError(
-                f"model_root_dir {self.model_root_dir} does not exist"
-            )
-
         self.cfg = cfg
         self.engine_cfg = cfg.get("engine_cfg", {})
         self._closed = False
@@ -288,6 +282,14 @@ class TRTInferSession(InferSession):
     def _get_engine_path(self, cfg: Dict[str, Any]) -> Path:
         cache_dir = self.engine_cfg.get("cache_dir")
         if cache_dir is None:
+            # Check model_root_dir only if cache_dir is None
+            if self.model_root_dir is None:
+                self.model_root_dir = Path(cfg.get("model_root_dir"))
+                if not self.model_root_dir.exists():
+                    raise FileNotFoundError(
+                        f"model_root_dir {self.model_root_dir} does not exist"
+                    )
+
             cache_dir = self.model_root_dir / "models"
 
         cache_dir = Path(cache_dir)
@@ -370,6 +372,14 @@ class TRTInferSession(InferSession):
             )
 
             cfg.engine_type = original_engine_type
+
+            # Check model_root_dir only if model_path is None
+            if self.model_root_dir is None:
+                self.model_root_dir = Path(cfg.get("model_root_dir"))
+                if not self.model_root_dir.exists():
+                    raise FileNotFoundError(
+                        f"model_root_dir {self.model_root_dir} does not exist"
+                    )
 
             model_path = self.model_root_dir / Path(model_info["model_dir"]).name
             download_params = DownloadFileInput(


### PR DESCRIPTION
修复在部分场景中已经指定了model_path，但是没有指定model_root_dir的情况下还会去检查model_root_dir导致的Path(None) Error.