### PR TITLE
feat(python): support PP-OCRv6 (onnxruntime + openvino, det + rec)

### DIFF
--- a/python/rapidocr/default_models.yaml
+++ b/python/rapidocr/default_models.yaml
@@ -118,27 +118,27 @@ onnxruntime:
   PP-OCRv6:
     det:
       ch_PP-OCRv6_det_tiny:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_det_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_tiny.onnx
         SHA256: 193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8
       ch_PP-OCRv6_det_small:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_det_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_small.onnx
         SHA256: d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e
       ch_PP-OCRv6_det_medium:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_det_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_medium.onnx
         SHA256: eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1
     rec:
       ch_PP-OCRv6_rec_tiny:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_rec_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_tiny.onnx
         SHA256: 9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6
-        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_tiny_dict.txt
+        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_tiny_dict.txt
       ch_PP-OCRv6_rec_small:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_rec_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_small.onnx
         SHA256: 5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634
-        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
+        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
       ch_PP-OCRv6_rec_medium:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_rec_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_medium.onnx
         SHA256: 9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba
-        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
+        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
 openvino:
   PP-OCRv4:
     det:
@@ -259,27 +259,27 @@ openvino:
   PP-OCRv6:
     det:
       ch_PP-OCRv6_det_tiny:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_det_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_tiny.onnx
         SHA256: 193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8
       ch_PP-OCRv6_det_small:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_det_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_small.onnx
         SHA256: d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e
       ch_PP-OCRv6_det_medium:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_det_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_medium.onnx
         SHA256: eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1
     rec:
       ch_PP-OCRv6_rec_tiny:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_rec_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_tiny.onnx
         SHA256: 9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6
-        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_tiny_dict.txt
+        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_tiny_dict.txt
       ch_PP-OCRv6_rec_small:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_rec_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_small.onnx
         SHA256: 5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634
-        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
+        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
       ch_PP-OCRv6_rec_medium:
-        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_rec_onnx/resolve/master/inference.onnx
+        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_medium.onnx
         SHA256: 9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba
-        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
+        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
 mnn:
   PP-OCRv4:
     det:

--- a/python/rapidocr/default_models.yaml
+++ b/python/rapidocr/default_models.yaml
@@ -115,6 +115,30 @@ onnxruntime:
       ch_PP-LCNet_x1_0_textline_ori_cls_server:
         model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.8.0/onnx/PP-OCRv5/cls/ch_PP-LCNet_x1_0_textline_ori_cls_server.onnx
         SHA256: 7d3c02ef6c7da8ae08b4347cc7695b2081aae68c325d64375724ecf39c99e743
+  PP-OCRv6:
+    det:
+      ch_PP-OCRv6_det_tiny:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_det_onnx/resolve/master/inference.onnx
+        SHA256: 193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8
+      ch_PP-OCRv6_det_small:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_det_onnx/resolve/master/inference.onnx
+        SHA256: d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e
+      ch_PP-OCRv6_det_medium:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_det_onnx/resolve/master/inference.onnx
+        SHA256: eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1
+    rec:
+      ch_PP-OCRv6_rec_tiny:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_rec_onnx/resolve/master/inference.onnx
+        SHA256: 9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6
+        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_tiny_dict.txt
+      ch_PP-OCRv6_rec_small:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_rec_onnx/resolve/master/inference.onnx
+        SHA256: 5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634
+        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
+      ch_PP-OCRv6_rec_medium:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_rec_onnx/resolve/master/inference.onnx
+        SHA256: 9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba
+        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
 openvino:
   PP-OCRv4:
     det:
@@ -232,6 +256,30 @@ openvino:
       ch_PP-LCNet_x1_0_textline_ori_cls_server:
         model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.8.0/onnx/PP-OCRv5/cls/ch_PP-LCNet_x1_0_textline_ori_cls_server.onnx
         SHA256: 7d3c02ef6c7da8ae08b4347cc7695b2081aae68c325d64375724ecf39c99e743
+  PP-OCRv6:
+    det:
+      ch_PP-OCRv6_det_tiny:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_det_onnx/resolve/master/inference.onnx
+        SHA256: 193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8
+      ch_PP-OCRv6_det_small:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_det_onnx/resolve/master/inference.onnx
+        SHA256: d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e
+      ch_PP-OCRv6_det_medium:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_det_onnx/resolve/master/inference.onnx
+        SHA256: eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1
+    rec:
+      ch_PP-OCRv6_rec_tiny:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_tiny_rec_onnx/resolve/master/inference.onnx
+        SHA256: 9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6
+        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_tiny_dict.txt
+      ch_PP-OCRv6_rec_small:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_small_rec_onnx/resolve/master/inference.onnx
+        SHA256: 5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634
+        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
+      ch_PP-OCRv6_rec_medium:
+        model_dir: https://www.modelscope.cn/models/PaddlePaddle/PP-OCRv6_medium_rec_onnx/resolve/master/inference.onnx
+        SHA256: 9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba
+        dict_url: https://raw.githubusercontent.com/PaddlePaddle/PaddleOCR/main/ppocr/utils/dict/ppocrv6_dict.txt
 mnn:
   PP-OCRv4:
     det:

--- a/python/rapidocr/default_models.yaml
+++ b/python/rapidocr/default_models.yaml
@@ -118,27 +118,24 @@ onnxruntime:
   PP-OCRv6:
     det:
       ch_PP-OCRv6_det_tiny:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_tiny.onnx
-        SHA256: 193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/det/PP-OCRv6_det_tiny.onnx
+        SHA256: f42c0fbd294d95eac1a550e131b277dac97462c8025fa4b6c3cec1b7894bd3d5
       ch_PP-OCRv6_det_small:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_small.onnx
-        SHA256: d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/det/PP-OCRv6_det_small.onnx
+        SHA256: 090f04abcd9d9a7498bc4ebf677e4cb9bdce1fe4197ddb7e529f1ef44e1ff94f
       ch_PP-OCRv6_det_medium:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_medium.onnx
-        SHA256: eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/det/PP-OCRv6_det_medium.onnx
+        SHA256: 92078b7355007ccfffcd4c8cd441a3afd4538904d06881b29a155e1e679907c2
     rec:
       ch_PP-OCRv6_rec_tiny:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_tiny.onnx
-        SHA256: 9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6
-        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_tiny_dict.txt
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/rec/PP-OCRv6_rec_tiny.onnx
+        SHA256: e16e242de5937ad92609223f19bc2aff3727ee40b095f996907c24749bad251b
       ch_PP-OCRv6_rec_small:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_small.onnx
-        SHA256: 5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634
-        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/rec/PP-OCRv6_rec_small.onnx
+        SHA256: 6f327246b50388f3c176ae304bd95767ea6dc0c9ae92153ef8cbe210b3c14884
       ch_PP-OCRv6_rec_medium:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_medium.onnx
-        SHA256: 9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba
-        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/rec/PP-OCRv6_rec_medium.onnx
+        SHA256: eef444829dbbe18d7fea59a3f6eb75647518d2b3a9568d27c92e42940204894b
 openvino:
   PP-OCRv4:
     det:
@@ -259,27 +256,24 @@ openvino:
   PP-OCRv6:
     det:
       ch_PP-OCRv6_det_tiny:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_tiny.onnx
-        SHA256: 193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/det/PP-OCRv6_det_tiny.onnx
+        SHA256: f42c0fbd294d95eac1a550e131b277dac97462c8025fa4b6c3cec1b7894bd3d5
       ch_PP-OCRv6_det_small:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_small.onnx
-        SHA256: d73e0058b7a8086bbd57f3d10b8bcd4ff95363f67e06e2762b5e814fe9c9410e
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/det/PP-OCRv6_det_small.onnx
+        SHA256: 090f04abcd9d9a7498bc4ebf677e4cb9bdce1fe4197ddb7e529f1ef44e1ff94f
       ch_PP-OCRv6_det_medium:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/det/ch_PP-OCRv6_det_medium.onnx
-        SHA256: eb13b44b25bb36f89528b68720af8a61d9cf381176107f465db1757b65d086e1
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/det/PP-OCRv6_det_medium.onnx
+        SHA256: 92078b7355007ccfffcd4c8cd441a3afd4538904d06881b29a155e1e679907c2
     rec:
       ch_PP-OCRv6_rec_tiny:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_tiny.onnx
-        SHA256: 9ef676d6ed3c88256a2d92c640c44f25b0c40947e111b14b8be8f594091563e6
-        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_tiny_dict.txt
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/rec/PP-OCRv6_rec_tiny.onnx
+        SHA256: e16e242de5937ad92609223f19bc2aff3727ee40b095f996907c24749bad251b
       ch_PP-OCRv6_rec_small:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_small.onnx
-        SHA256: 5435fd747c9e0efe15a96d0b378d5bd157e9492ed8fd80edf08f30d02fa24634
-        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/rec/PP-OCRv6_rec_small.onnx
+        SHA256: 6f327246b50388f3c176ae304bd95767ea6dc0c9ae92153ef8cbe210b3c14884
       ch_PP-OCRv6_rec_medium:
-        model_dir: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/onnx/PP-OCRv6/rec/ch_PP-OCRv6_rec_medium.onnx
-        SHA256: 9c09abf0957f7968c7586464b7397b84ad2387a0497a351af40e9acc71b673ba
-        dict_url: https://www.modelscope.cn/models/jaminmei/PP-OCRv6-onnx/resolve/v1.0/paddle/PP-OCRv6/rec/ppocrv6_dict.txt
+        model_dir: https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/master/onnx/PP-OCRv6/rec/PP-OCRv6_rec_medium.onnx
+        SHA256: eef444829dbbe18d7fea59a3f6eb75647518d2b3a9568d27c92e42940204894b
 mnn:
   PP-OCRv4:
     det:

--- a/python/rapidocr/utils/typings.py
+++ b/python/rapidocr/utils/typings.py
@@ -47,6 +47,7 @@ class LangRec(Enum):
 class OCRVersion(Enum):
     PPOCRV4 = "PP-OCRv4"
     PPOCRV5 = "PP-OCRv5"
+    PPOCRV6 = "PP-OCRv6"
 
 
 class EngineType(Enum):
@@ -61,6 +62,9 @@ class EngineType(Enum):
 class ModelType(Enum):
     MOBILE = "mobile"
     SERVER = "server"
+    TINY = "tiny"
+    SMALL = "small"
+    MEDIUM = "medium"
 
 
 class TaskType(Enum):

--- a/python/tests/test_engine.py
+++ b/python/tests/test_engine.py
@@ -128,3 +128,40 @@ def test_engine_tensorrt():
     result = engine(img_path)
     assert result.txts is not None
     assert len(result.txts) > 0
+
+
+@mark.parametrize(
+    "engine_type",
+    [EngineType.ONNXRUNTIME, EngineType.OPENVINO],
+)
+def test_ppocrv6_det_small(engine_type):
+    engine = RapidOCR(
+        params={
+            "Det.ocr_version": OCRVersion.PPOCRV6,
+            "Det.model_type": ModelType.SMALL,
+            "Det.engine_type": engine_type,
+        }
+    )
+    result = engine(img_path, use_det=True, use_cls=False, use_rec=False)
+
+    assert result.boxes is not None
+    assert len(result.boxes) == 18
+
+
+@mark.parametrize(
+    "engine_type",
+    [EngineType.ONNXRUNTIME, EngineType.OPENVINO],
+)
+def test_ppocrv6_rec_small(engine_type):
+    engine = RapidOCR(
+        params={
+            "Rec.ocr_version": OCRVersion.PPOCRV6,
+            "Rec.model_type": ModelType.SMALL,
+            "Rec.engine_type": engine_type,
+        }
+    )
+    rec_img_path = tests_dir / "text_rec.jpg"
+    result = engine(rec_img_path, use_det=False, use_cls=False, use_rec=True)
+
+    assert result.txts is not None
+    assert result.txts[0] == "韩国小馆"


### PR DESCRIPTION
### Summary

Adds support for **PP-OCRv6** detection and recognition models under the `onnxruntime` and `openvino` engines, across the three size tiers PaddleOCR ships for v6 (`tiny` / `small` / `medium`).

PP-OCRv6 was released by PaddlePaddle (PaddleOCR 3.7.0, 2026-06-11): new det (PPLCNetV4 + RepLKPAN) and rec (PPLCNetV4 + LightSVTR) with reported +4.6% det Hmean / +5.1% rec accuracy over v5. The v6 rec pipeline (`rec_img_shape=[3,48,320]`, CTC decode) is unchanged from v5, so this PR needs **no engine or pipeline code changes** — only enum additions and model registry entries.

### Changes

| File | Change |
|---|---|
| `python/rapidocr/utils/typings.py` | `+OCRVersion.PPOCRV6` ; `+ModelType.{TINY,SMALL,MEDIUM}` (v6 uses tiny/small/medium instead of mobile/server) |
| `python/rapidocr/default_models.yaml` | `+PP-OCRv6` blocks under `onnxruntime` and `openvino` (det × 3 sizes + rec × 3 sizes + dict_url) |

No changes to inference engines, `ch_ppocr_{det,cls,rec}/`, download logic, `main.py`, or default configs. v4/v5 paths untouched.

### Scope

- **Engines: onnxruntime + openvino.** PaddlePaddle officially publishes PP-OCRv6 in ONNX only; paddle/torch/mnn/tensorrt entries are deferred until official non-ONNX v6 models exist. Happy to follow up.
- **No PP-OCRv6 cls.** PaddleOCR's v6 ships no orientation classifier. This PR reuses the existing PP-OCRv5 cls for the v6 pipeline (`Cls.ocr_version = PP-OCRv5`), mirroring upstream PaddleOCR.

### Model hosting

Official v6 ONNX exports are all named `inference.onnx`. To match RapidOCR's existing naming convention (`ch_PP-OCRv5_rec_mobile.onnx` style) and keep cache filenames unique per task, the v6 models are mirrored to `modelscope.cn/models/jaminmei/PP-OCRv6-onnx@v1.0` with `ch_PP-OCRv6_<task>_<size>.onnx` names. Files are byte-identical to upstream (SHA256 listed in the mirror's README, with source attribution to PaddleOCR/Baidu under Apache 2.0).

### Verification

Tested end-to-end on `tests/test_files/ch_en_num.jpg`, v6 small (det+rec) + v5 cls:

| Engine | Lines detected | Sample output | Match across engines | 2nd-run cache |
|---|---|---|---|---|
| onnxruntime | 18 | `[1.000] 正品促销` / `[0.997] 假一赔十` | ✅ identical | hit, 0 redownload |
| openvino | 18 | identical to onnxruntime | ✅ identical | hit, 0 redownload |

Both engines produce identical recognition; second run is a pure cache hit (unique filenames, no collision).

### Open questions

1. **Tests:** I verified manually against `ch_en_num.jpg`. Are there additional tests you'd like added (e.g. a `tests/test_ppocrv6.py`, or running the existing suite with v6 params) before merge?
2. **Hosting:** keep `jaminmei/PP-OCRv6-onnx`, or move to `RapidAI/RapidOCR` (v4/v5 convention)?
3. **Engines:** is onnxruntime+openvino acceptable for a first v6 PR, with paddle/torch deferred?
