### PR TITLE
fix: avoid cv2 dependency in prepare_wheel_assets.py

### DIFF
--- a/python/tools/prepare_wheel_assets.py
+++ b/python/tools/prepare_wheel_assets.py
@@ -4,6 +4,7 @@
 import argparse
 import hashlib
 import sys
+import types
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,6 +12,18 @@ from typing import Iterable, List, Optional
 
 PYTHON_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PYTHON_ROOT))
+
+# Register lightweight package stubs so that Python can resolve
+# ``rapidocr.utils.*`` without executing ``rapidocr/__init__.py``,
+# which pulls in cv2, numpy, and other heavy runtime dependencies
+# that this script does not need.
+_pkg = types.ModuleType("rapidocr")
+_pkg.__path__ = [str(PYTHON_ROOT / "rapidocr")]
+sys.modules.setdefault("rapidocr", _pkg)
+
+_utils_pkg = types.ModuleType("rapidocr.utils")
+_utils_pkg.__path__ = [str(PYTHON_ROOT / "rapidocr" / "utils")]
+sys.modules.setdefault("rapidocr.utils", _utils_pkg)
 
 from rapidocr.utils.model_resolver import normalize_lang, resolve_model_key
 from rapidocr.utils.typings import ModelType, OCRVersion, TaskType


### PR DESCRIPTION
## Summary

- `prepare_wheel_assets.py` only needs `model_resolver` and `typings` from `rapidocr.utils`, but importing them through the normal package path triggers `rapidocr/__init__.py`, which pulls in `cv2`, `numpy`, and `omegaconf` via `main.py`
- Fix by registering lightweight package stubs in `sys.modules` before the imports, so Python resolves the submodules directly without executing `rapidocr/__init__.py`
- Both target modules (`typings.py` and `model_resolver.py`) are self-contained with only stdlib dependencies, so bypassing `__init__.py` is safe

Fixes #709

## Test plan

- [x] Verified `python python/tools/prepare_wheel_assets.py --help` succeeds without cv2/numpy/omegaconf installed
- [x] Verified the script still imports `normalize_lang`, `resolve_model_key`, `ModelType`, `OCRVersion`, and `TaskType` correctly