### PR TITLE
docs: add GPU (CUDA/Tesla T4) quickstart section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+Notes for AI coding agents (and humans) working with RapidOCR's Python package, especially around GPU/inference-engine behavior that is easy to get wrong. These are documentation notes only — no code behavior described here has changed.
+
+## Default backend runs on CPU, silently
+
+The default engine config has `EngineConfig.onnxruntime.use_cuda=false`. If you install `pip install rapidocr onnxruntime` (the README quickstart command) and construct `RapidOCR()` on a machine with an NVIDIA GPU, it will run entirely on CPU with **no warning or error** — all of det/cls/rec sessions report `CPUExecutionProvider`.
+
+If you expect GPU execution, verify it explicitly after building the engine:
+
+```python
+print(engine.text_det.session.session.get_providers())
+```
+
+Expect `CUDAExecutionProvider` first in the list. If you only see `CPUExecutionProvider` / `AzureExecutionProvider`, the GPU is not being used.
+
+## Getting the default (onnxruntime) backend onto GPU requires three things together
+
+1. `onnxruntime-gpu` installed instead of plain `onnxruntime` (version must match your CUDA/cuDNN).
+2. `EngineConfig.onnxruntime.use_cuda=True` passed via `RapidOCR(params=...)`.
+3. A matching CUDA/cuDNN runtime available at runtime (system CUDA, or the pip `nvidia-*-cu12` packages plus `LD_LIBRARY_PATH`).
+
+All three are required — any one missing falls back to CPU. If `use_cuda=True` is set but `onnxruntime-gpu` isn't installed, RapidOCR does print an installation hint log (not silent in that specific case); but the CPU-by-default case above produces no log at all.
+
+## T4/Turing measurements (default onnxruntime backend)
+
+Measured on a real Tesla T4 (16GB, Turing, sm_75), `ch_en_num.jpg` (430x323), det+cls+rec pipeline via the public `RapidOCR()` API:
+
+| | providers | mean latency | peak VRAM |
+|---|---|---|---|
+| CPU | CPUExecutionProvider x3 | 503.8 ms | 0 |
+| CUDA (T4) | CUDAExecutionProvider x3 | 150.6 ms | ~0.55 GB |
+
+That's a **3.34x** speedup with identical OCR output (18 boxes, same recognized text). GPU utilization was confirmed non-idle (peak ~40% over a sustained loop), so this is real GPU execution, not just provider registration.
+
+## Precision / quantization
+
+- The default onnxruntime backend's ONNX models are **fp32** (`tensor(float)` inputs), and ONNX Runtime does not autocast. There is no bf16-on-Turing pitfall here — this backend is safe on T4-class (sm_75) GPUs from a dtype standpoint.
+- RapidOCR does **not** ship int8 or fp16 quantized ONNX model variants for the onnxruntime backend (`default_models.yaml` has none).
+- fp16/int8 acceleration is only available through the separate **tensorrt** backend (`EngineConfig.tensorrt.use_fp16` defaults to `true`, `use_int8` is an option), which requires its own TensorRT installation and engine build step — it is not a drop-in flag for the onnxruntime backend.
+
+## Quick checklist for GPU work on this repo
+
+- Installing `onnxruntime-gpu` alone is **not** enough — you also need `use_cuda=True`.
+- Setting `use_cuda=True` alone is **not** enough — you also need `onnxruntime-gpu` installed and a matching CUDA/cuDNN runtime.
+- Always confirm the actual provider via `get_providers()` rather than assuming config flags took effect.
+- If you need fp16/int8, use the `tensorrt` backend, not the default `onnxruntime` backend.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,42 @@ print(result)
 result.vis("vis_result.jpg")
 ```
 
+### 🚀 GPU Quickstart (onnxruntime backend)
+
+The default install (`pip install rapidocr onnxruntime`) is **CPU-only**. `RapidOCR()` will run on CPU with **no warning**, even on a machine with a GPU, because the default `onnxruntime` package has no CUDA execution provider and the default config has `EngineConfig.onnxruntime.use_cuda=False`.
+
+To actually use an NVIDIA GPU (e.g. Tesla T4) with the default `onnxruntime` backend, all **three** of the following are required — missing any one silently falls back to CPU:
+
+1. Swap the ONNX Runtime package for the GPU build (match the version to your CUDA/cuDNN):
+   ```bash
+   pip uninstall onnxruntime
+   pip install onnxruntime-gpu
+   ```
+2. Enable CUDA in the engine config:
+   ```python
+   from rapidocr import RapidOCR
+
+   engine = RapidOCR(params={"EngineConfig.onnxruntime.use_cuda": True})
+   ```
+3. Make sure a matching CUDA/cuDNN runtime is available. If there is no system-wide CUDA install, the pip CUDA runtime packages work (adjust for your CUDA major version):
+   ```bash
+   pip install nvidia-cuda-runtime-cu12 nvidia-cudnn-cu12 nvidia-cublas-cu12 nvidia-cufft-cu12 nvidia-curand-cu12
+   export LD_LIBRARY_PATH=$(python -c "import nvidia, os; print(os.path.dirname(os.path.dirname(nvidia.__file__)))")/nvidia/*/lib:$LD_LIBRARY_PATH
+   ```
+
+To confirm the GPU is actually being used, check the effective execution provider after building the engine:
+
+```python
+print(engine.text_det.session.session.get_providers())
+# Expect CUDAExecutionProvider first, not CPUExecutionProvider
+```
+
+Measured on a Tesla T4 (16GB, Turing, sm_75): mean latency on a 430x323 image dropped from **503.8ms (CPU)** to **150.6ms (CUDA)** — a **3.34x** speedup, with the same OCR result. Peak VRAM usage was ~0.55GB, well within the T4's 16GB.
+
+If `use_cuda=True` is set but `onnxruntime-gpu` is not installed, RapidOCR logs an installation hint rather than failing silently — but with the default CPU-only `onnxruntime` package and `use_cuda=False` (the defaults), there is no warning at all.
+
+See [AGENTS.md](./AGENTS.md) for further GPU/precision notes (fp32 vs fp16/int8, backend selection).
+
 ### 🐳 Docker
 
 Docker development environments are available for all supported inference engines:


### PR DESCRIPTION
## Motivation

The quickstart install (`pip install rapidocr onnxruntime`) is CPU-only, and `RapidOCR()` runs on CPU with **no warning** even on a machine with an NVIDIA GPU — the default `onnxruntime` package has no CUDA execution provider, and the default engine config has `EngineConfig.onnxruntime.use_cuda=False`. Neither the README, quickstart, install, nor usage docs mention what's needed to get the default onnxruntime backend onto GPU (the usage docs only show a `torch` backend GPU example).

Verified on a real Tesla T4 (16GB, Turing, sm_75) that GPU execution requires **three** things together — missing any one silently falls back to CPU:
1. `onnxruntime-gpu` installed instead of plain `onnxruntime`
2. `EngineConfig.onnxruntime.use_cuda=True`
3. A matching CUDA/cuDNN runtime (system CUDA, or pip `nvidia-*-cu12` packages + `LD_LIBRARY_PATH`)

## Changes

Doc-only, no code changes:
- **README.md**: new "GPU Quickstart (onnxruntime backend)" section right after Usage, spelling out the three required steps, how to verify the effective execution provider (`get_providers()`), and the measured T4 speedup.
- **AGENTS.md** (new): notes for AI agents/contributors on the CPU-by-default silent behavior, the three-part GPU requirement, T4 measurements, and precision/quantization details (default backend is fp32-only ONNX with no ORT autocast, so there's no bf16-on-Turing risk; int8/fp16 quantized variants are only available via the separate `tensorrt` backend, not the default `onnxruntime` backend).

## Testing

Measured directly on a Tesla T4 (16GB, Turing, sm_75) using the public `RapidOCR()` API (`ch_en_num.jpg`, 430x323, det+cls+rec):

| | providers | mean latency | peak VRAM |
|---|---|---|---|
| CPU | CPUExecutionProvider x3 | 503.8 ms | 0 |
| CUDA (T4) | CUDAExecutionProvider x3 | 150.6 ms | ~0.55 GB |

**150.6ms vs 503.8ms = 3.34x speedup**, identical OCR output (18 boxes, same recognized text) in both cases. GPU utilization was confirmed non-idle over a sustained loop (peak ~40%), so this reflects real GPU execution rather than idle provider registration.

No source files were changed — this PR only adds documentation.