### PR TITLE
fix(mnn): use getNumpyData() instead of getData() for output extraction (~3x rec speedup)

### DIFF
--- a/python/rapidocr/inference_engine/mnn/main.py
+++ b/python/rapidocr/inference_engine/mnn/main.py
@@ -73,8 +73,7 @@ class MNNInferSession(InferSession):
                 out_shape, MNN.Halide_Type_Float, MNN.Tensor_DimensionType_Caffe
             )
             output.copyToHostTensor(out_tensor)
-
-            return np.array(out_tensor.getData()).reshape(out_shape)
+            return np.array(out_tensor.getNumpyData(), copy=True).reshape(out_shape)
 
         except Exception as e:
             error_info = traceback.format_exc()


### PR DESCRIPTION
## Problem

`MNNInferSession.__call__` in `rapidocr/inference_engine/mnn/main.py` extracts
the session output via:

```python
out_tensor = MNN.Tensor(out_shape, MNN.Halide_Type_Float, MNN.Tensor_DimensionType_Caffe)
output.copyToHostTensor(out_tensor)
return np.array(out_tensor.getData()).reshape(out_shape)
```

`getData()` marshals the tensor contents through a slow per-element Python
path rather than exposing the buffer directly. For a PP-OCRv6 medium
recognizer output of shape `(1, ~230, 18710)` (~17MB), this step alone took
**~450ms** on our test hardware (RK3588, OpenCL backend), compared to
~210ms for the actual GPU inference (`runSession`) that produced it — i.e.
result extraction was costing more than twice as much as inference itself.

On a real-world image with 39 detected text boxes, this pushed total
recognition time from an expected ~9s to **~22s**.

## Fix

Use the buffer-protocol-based `getNumpyData()` instead, which is already
exposed on the MNN Python binding:

```python
result = out_tensor.getNumpyData()
result = np.array(result, copy=True).reshape(out_shape)
```

The explicit `copy=True` is required — `getNumpyData()` returns a view into
memory owned by `out_tensor`. Without an explicit copy, we observed
intermittent segfaults once `out_tensor` went out of scope / was reused
across calls with different session shapes. With the copy forced, this
was fully stable across repeated runs and varying input shapes/batches.

## Results (RK3588, OpenCL backend, PP-OCRv6 medium recognizer)

| | before | after |
|---|---|---|
| per-crop output extraction | ~454ms | ~10ms |
| per-crop total (`__call__`) | ~690ms | ~240ms |
| 39-box real image, total rec time | ~22s | ~8.4s |

The remaining ~10ms for extraction is a legitimate memcpy+reshape cost for
~17MB of data and is not further addressed here.

## Testing

- Verified numerical output is identical to the old `getData()` path via
  `np.allclose` on sampled outputs.
- Verified stability across varying crop widths/batch sizes (no segfaults
  over repeated runs, including shape changes between calls).
- Benchmarked before/after on a real multi-box image end-to-end.

## Notes

This affects every user of the MNN engine backend, independent of model,
backend device (CPU/OpenCL/Vulkan), or hardware — it's a fixed cost in the
Python-level extraction path, not specific to our setup.