### PR TITLE
fix: lock lazy model load so first use constructs once

### DIFF
--- a/python/rapidocr/main.py
+++ b/python/rapidocr/main.py
@@ -3,6 +3,7 @@
 # @Contact: liekkaskono@163.com
 import argparse
 import copy
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -67,12 +68,15 @@ class RapidOCR:
 
         self.use_det = cfg.Global.use_det
         self.text_det = None
+        self._det_model_lock = threading.Lock()
 
         self.use_cls = cfg.Global.use_cls
         self.text_cls = None
+        self._cls_model_lock = threading.Lock()
 
         self.use_rec = cfg.Global.use_rec
         self.text_rec = None
+        self._rec_model_lock = threading.Lock()
 
         self.load_img = LoadImage()
         self.max_side_len = cfg.Global.max_side_len
@@ -117,30 +121,36 @@ class RapidOCR:
 
     def _load_det_model(self):
         if self.text_det is None:
-            self.cfg.Det.engine_cfg = self.cfg.EngineConfig[
-                self.cfg.Det.engine_type.value
-            ]
-            self.cfg.Det.model_root_dir = self.cfg.Global.model_root_dir
-            self.text_det = TextDetector(self.cfg.Det)
+            with self._det_model_lock:
+                if self.text_det is None:
+                    self.cfg.Det.engine_cfg = self.cfg.EngineConfig[
+                        self.cfg.Det.engine_type.value
+                    ]
+                    self.cfg.Det.model_root_dir = self.cfg.Global.model_root_dir
+                    self.text_det = TextDetector(self.cfg.Det)
         return self.text_det
 
     def _load_cls_model(self):
         if self.text_cls is None:
-            self.cfg.Cls.engine_cfg = self.cfg.EngineConfig[
-                self.cfg.Cls.engine_type.value
-            ]
-            self.cfg.Cls.model_root_dir = self.cfg.Global.model_root_dir
-            self.text_cls = TextClassifier(self.cfg.Cls)
+            with self._cls_model_lock:
+                if self.text_cls is None:
+                    self.cfg.Cls.engine_cfg = self.cfg.EngineConfig[
+                        self.cfg.Cls.engine_type.value
+                    ]
+                    self.cfg.Cls.model_root_dir = self.cfg.Global.model_root_dir
+                    self.text_cls = TextClassifier(self.cfg.Cls)
         return self.text_cls
 
     def _load_rec_model(self):
         if self.text_rec is None:
-            self.cfg.Rec.engine_cfg = self.cfg.EngineConfig[
-                self.cfg.Rec.engine_type.value
-            ]
-            self.cfg.Rec.font_path = self.cfg.Global.font_path
-            self.cfg.Rec.model_root_dir = self.cfg.Global.model_root_dir
-            self.text_rec = TextRecognizer(self.cfg.Rec)
+            with self._rec_model_lock:
+                if self.text_rec is None:
+                    self.cfg.Rec.engine_cfg = self.cfg.EngineConfig[
+                        self.cfg.Rec.engine_type.value
+                    ]
+                    self.cfg.Rec.font_path = self.cfg.Global.font_path
+                    self.cfg.Rec.model_root_dir = self.cfg.Global.model_root_dir
+                    self.text_rec = TextRecognizer(self.cfg.Rec)
         return self.text_rec
 
     def run_ocr_steps(self, img: np.ndarray, op_record: Dict[str, Any]):

--- a/python/tests/test_lazy_model_load.py
+++ b/python/tests/test_lazy_model_load.py
@@ -1,0 +1,70 @@
+# -*- encoding: utf-8 -*-
+# @Author: SWHL
+# @Contact: liekkaskono@163.com
+import threading
+import time
+
+import pytest
+
+import rapidocr.main as main_module
+from rapidocr import RapidOCR
+
+THREAD_COUNT = 8
+
+
+@pytest.mark.parametrize(
+    ("loader_name", "model_attr", "ctor_name"),
+    [
+        ("_load_det_model", "text_det", "TextDetector"),
+        ("_load_cls_model", "text_cls", "TextClassifier"),
+        ("_load_rec_model", "text_rec", "TextRecognizer"),
+    ],
+)
+def test_lazy_model_load_constructs_once_under_concurrent_first_use(
+    monkeypatch, loader_name, model_attr, ctor_name
+):
+    engine = RapidOCR()
+    assert getattr(engine, model_attr) is None
+
+    constructed = []
+    first_ctor_started = threading.Event()
+    release_ctors = threading.Event()
+    start_barrier = threading.Barrier(THREAD_COUNT)
+    errors = []
+    results = []
+
+    class BlockingModel:
+        def __init__(self, cfg):
+            constructed.append(self)
+            first_ctor_started.set()
+            # Keep the instance unset until every racer has tried to construct.
+            release_ctors.wait(timeout=5)
+
+    monkeypatch.setattr(main_module, ctor_name, BlockingModel)
+
+    def worker():
+        try:
+            start_barrier.wait(timeout=5)
+            results.append(getattr(engine, loader_name)())
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(THREAD_COUNT)]
+    for thread in threads:
+        thread.start()
+
+    assert first_ctor_started.wait(timeout=5)
+    deadline = time.monotonic() + 0.2
+    while time.monotonic() < deadline and len(constructed) < THREAD_COUNT:
+        time.sleep(0.01)
+
+    release_ctors.set()
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert errors == []
+    assert len(constructed) == 1
+    assert len(results) == THREAD_COUNT
+    assert all(result is constructed[0] for result in results)
+    assert getattr(engine, model_attr) is constructed[0]


### PR DESCRIPTION
Concurrent first calls could initialize det/cls/rec more than once. Double-check each loader under its own lock. Fixes #724.