### PR TITLE
fix: load torch weights with weights_only=True to prevent code execution

### DIFF
--- a/python/rapidocr/inference_engine/pytorch/networks/main.py
+++ b/python/rapidocr/inference_engine/pytorch/networks/main.py
@@ -62,6 +62,6 @@ class ModelLoader:
 
     def _build_and_load_model(self, arch_config, model_path: Path):
         model = BaseModel(arch_config)
-        state_dict = torch.load(model_path, map_location="cpu", weights_only=False)
+        state_dict = torch.load(model_path, map_location="cpu", weights_only=True)
         model.load_state_dict(state_dict)
         return model


### PR DESCRIPTION
`weights_only=False` is unsafe because pickle files can execute arbitrary code.