### PR TITLE
fix(nrtr): let generate_square_subsequent_mask take the device it is given

### DIFF
--- a/python/rapidocr/inference_engine/pytorch/networks/heads/rec_nrtr_head.py
+++ b/python/rapidocr/inference_engine/pytorch/networks/heads/rec_nrtr_head.py
@@ -355,13 +355,18 @@ class Transformer(nn.Module):
             torch.tensor(hyp_scores),
         ]
 
-    def generate_square_subsequent_mask(self, sz):
+    def generate_square_subsequent_mask(self, sz, device=None):
         """Generate a square mask for the sequence. The masked positions are filled with float('-inf').
         Unmasked positions are filled with float(0.0).
         """
-        mask = torch.zeros([sz, sz], dtype=torch.float32)
+        mask = torch.zeros([sz, sz], dtype=torch.float32, device=device)
         mask_inf = torch.triu(
-            torch.full(size=[sz, sz], fill_value=float("-Inf"), dtype=torch.float32),
+            torch.full(
+                size=[sz, sz],
+                fill_value=float("-Inf"),
+                dtype=torch.float32,
+                device=device,
+            ),
             diagonal=1,
         )
         mask = mask + mask_inf


### PR DESCRIPTION
## The bug

`Transformer.forward_train` asks the mask helper for a device:

```python
tgt_mask = self.generate_square_subsequent_mask(tgt.shape[0], tgt.device)
```

but the helper only takes `sz`:

```python
def generate_square_subsequent_mask(self, sz):
```

so the training branch of `Transformer.forward` (`if self.training:`) raises:

```
TypeError: Transformer.generate_square_subsequent_mask() takes 2 positional arguments but 3 were given
```

The other two call sites in the same class — `forward_test` (line 167) and
`forward_beam` (line 261) — pass a single argument and match the signature,
which is why the inference paths RapidOCR actually exercises are unaffected
and this has gone unnoticed.

## The fix

Accept an optional `device` and forward it to the two tensor constructors:

```python
-def generate_square_subsequent_mask(self, sz):
+def generate_square_subsequent_mask(self, sz, device=None):
-    mask = torch.zeros([sz, sz], dtype=torch.float32)
+    mask = torch.zeros([sz, sz], dtype=torch.float32, device=device)
```

`device=None` is exactly `torch`'s own default, so the two one-argument call
sites build the mask on the CPU precisely as before; only the call site that
already asked for a device changes behaviour.

I picked this over deleting `tgt.device` from the call site because it is the
option that keeps a mask on the same device as the tensor it will be added to.

## Verification

Instantiated the real `Transformer` from this file (`d_model=32, nhead=4,
1 encoder + 1 decoder layer`) and ran both branches of `forward`:

```
-- BEFORE (main)
   train path: TypeError Transformer.generate_square_subsequent_mask() takes 2 positional arguments but 3 were given
   eval  path: ok, out[0] shape (2, 25)
-- AFTER  (patch)
   train path: ok (2, 7, 40)
   eval  path: ok, out[0] shape (2, 25)
```

Regression check on the path that already worked — same seeds (`torch` *and*
`numpy`, since `__init__` draws `tgt_word_prj` weights via `np.random.normal`),
no preceding train call, so the RNG state is identical:

```
eval/beam-free inference output bit-identical before vs after: True
  shapes: [(2, 25), (2, 25)]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
