### PR TITLE
fix(cls): default Cls.ocr_version to PP-OCRv5

### DIFF
--- a/python/rapidocr/config.yaml
+++ b/python/rapidocr/config.yaml
@@ -154,7 +154,7 @@ Cls:
     engine_type: "onnxruntime"
     lang_type: "ch"
     model_type: "mobile"
-    ocr_version: "PP-OCRv4"
+    ocr_version: "PP-OCRv5"
 
     task_type: "cls"
 


### PR DESCRIPTION
The `Cls` default is `ocr_version: "PP-OCRv4"`, and that entry in `default_models.yaml` resolves to:

```
onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx
```

i.e. the v2.0 classifier, filed under a `PP-OCRv4` directory. `PP-OCRv5` resolves to the newer
`ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx` instead.

I understand why the file is where it is — upstream PaddleOCR never released a v4-specific classifier,
so reusing the v2.0 one in the v4 bundle is reasonable packaging. The issue is that it is also the
**default**, so users who do not know to set `Cls.ocr_version` get the older classifier silently.

### It changes the output

Measured on 113 real page and crop images (French and English, mixed scanned and born-digital, taken
from PDFs), with everything else identical — PP-OCRv6 tiny det+rec, same thresholds, same resize
settings, ONNX Runtime on CPU:

| `Cls.ocr_version` | model loaded | characters recognised |
|---|---|---|
| `PP-OCRv4` (default) | `ch_ppocr_mobile_v2.0_cls_mobile.onnx` | 126,355 |
| `PP-OCRv5` | `ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx` | **128,895 (+2.01%)** |

44 of the 113 images produced different text, and the difference favoured `PP-OCRv5` in every case I
inspected. That is the shape you would expect from an orientation classifier: a line it calls
upside-down gets rotated before recognition, so a wrong call costs the whole line.

### No other config change is needed

`TextClassifier.__init__` derives the input shape from the version rather than from the config:

```python
CLS_SHAPE_BY_OCR_VERSION = {
    OCRVersion.PPOCRV4: [3, 48, 192],
    OCRVersion.PPOCRV5: [3, 80, 160],
}
self.cls_image_shape = CLS_SHAPE_BY_OCR_VERSION[cfg["ocr_version"]]
```

so the `[3, 80, 160]` the v5 model requires follows automatically, and the `cls_image_shape: [3, 48, 192]`
line in `config.yaml` is not read at all. (Possibly worth removing separately — it reads as a settable
knob but has no effect. Happy to open that as its own PR if you would like it.)

### Caveat

My corpus is French and English documents. The gain should hold for Latin-script text generally, but I
have not measured Chinese, so I cannot tell you this is an improvement on the corpus you most likely
care about. If it is neutral or negative there, please close this — the measurement is offered as
evidence, not as a claim about every language.
